### PR TITLE
Included a check if the selected language folder have translations. C…

### DIFF
--- a/src/SharedCode/EnvironmentHelper.cs
+++ b/src/SharedCode/EnvironmentHelper.cs
@@ -207,7 +207,23 @@ namespace InitSetting
                         }
                         else
                         {
-                            MessageBox.Show(Localizable.InstructDecideLang);
+                            //check if the folder have translations besides automatic ones (starting with "_")
+                            bool haveTranslations = false;
+                            string checkLanguageFolder = Path.Combine(GameRootDirectory, @"BepInEx/Translation/" + language.Substring(0, 2) + @"/Text/");
+                            if (Directory.Exists(checkLanguageFolder))
+                            {
+                                string[] checkLanguageFiles = Directory.GetFiles(checkLanguageFolder, "*", SearchOption.TopDirectoryOnly);
+                                foreach (string file in checkLanguageFiles)
+                                {
+                                    if (!Path.GetFileName(file).StartsWith("_"))
+                                    {
+                                        haveTranslations = true;
+                                        break;
+                                    }
+                                }
+                            }
+                            if (!haveTranslations)
+                                MessageBox.Show(Localizable.InstructDecideLang);
                         }
 
                         WriteAutoTranslatorLangIni(language);

--- a/src/SharedCode/EnvironmentHelper.cs
+++ b/src/SharedCode/EnvironmentHelper.cs
@@ -212,7 +212,7 @@ namespace InitSetting
                             string checkLanguageFolder = Path.Combine(GameRootDirectory, @"BepInEx/Translation/" + language.Substring(0, 2) + @"/Text/");
                             if (Directory.Exists(checkLanguageFolder))
                             {
-                                string[] checkLanguageFiles = Directory.GetFiles(checkLanguageFolder, "*", SearchOption.TopDirectoryOnly);
+                                string[] checkLanguageFiles = Directory.GetFiles(checkLanguageFolder, "*.txt", SearchOption.TopDirectoryOnly);
                                 foreach (string file in checkLanguageFiles)
                                 {
                                     if (!Path.GetFileName(file).StartsWith("_"))

--- a/src/SharedCode/Localizable.pt.resx
+++ b/src/SharedCode/Localizable.pt.resx
@@ -249,4 +249,7 @@ Algumas das ações presentes nessa obra de ficção podem ser ilegais ao serem 
   <data name="TogglePHIBL" xml:space="preserve">
     <value>Ativar PHIBL GraphicsMod</value>
   </data>
+  <data name="InstructDecideLang" xml:space="preserve">
+    <value>O idioma que você escolheu não possui traduções em sua instalação. A tradução será feita pelo Google Translate.</value>
+  </data>
 </root>


### PR DESCRIPTION
Included a check if the selected language folder have translation files besides the ones created automatically by XUA (files started with "_" in Text folder). Case positive it doesn't show the google translate message.
Also included a missing text in Portuguese.